### PR TITLE
Fix GitHub utilities and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Plaiful is using source code from the open source https://openalternative.co/ and assumes the same GLP-3.0 License
+Plaiful is using source code from the open source https://openalternative.co/ and assumes the same GPL-3.0 License
 
 Plaiful is the ultimate source for AI Agents.

--- a/apps/web/src/lib/rate-limiter.ts
+++ b/apps/web/src/lib/rate-limiter.ts
@@ -8,7 +8,7 @@ const limiters = {
   stackAnalysis: new Ratelimit({
     redis,
     analytics: true,
-    limiter: Ratelimit.slidingWindow(10, "12 h"), // 5 attempts per 12 hours
+    limiter: Ratelimit.slidingWindow(10, "12 h"), // 10 attempts per 12 hours
   }),
 
   submission: new Ratelimit({
@@ -22,7 +22,7 @@ const limiters = {
     analytics: true,
     limiter: Ratelimit.slidingWindow(2, "24 h"), // 2 attempts per day
   }),
-  
+
   "ai-search": new Ratelimit({
     redis,
     analytics: true,

--- a/packages/github/src/client.ts
+++ b/packages/github/src/client.ts
@@ -11,6 +11,10 @@ export const createGithubClient = (token: string) => {
   return {
     async queryRepository(repository: string): Promise<RepositoryData | null> {
       const repo = getRepository(repository)
+      if (!repo) {
+        console.error(`Invalid repository URL: ${repository}`)
+        return null
+      }
 
       try {
         const { repository } = await client<{ repository: RepositoryQueryResult }>(

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -10,10 +10,11 @@ export const githubRegex =
  * @param url The GitHub URL from which to extract the owner and name.
  * @returns An object containing the repository owner and name, or null if the URL is invalid.
  */
-export const getRepository = (url: string): Repository => {
+export const getRepository = (url: string): Repository | null => {
   const match = url.toLowerCase().match(githubRegex)
 
-  return match?.groups as Repository
+  if (!match || !match.groups) return null
+  return match.groups as Repository
 }
 
 /**
@@ -22,9 +23,10 @@ export const getRepository = (url: string): Repository => {
  * @param url The GitHub URL from which to extract the owner and name.
  * @returns The repository owner and name as a string.
  */
-export const getRepositoryString = (url: string) => {
-  const { owner, name } = getRepository(url)
-
+export const getRepositoryString = (url: string): string | null => {
+  const repo = getRepository(url)
+  if (!repo) return null
+  const { owner, name } = repo
   return `${owner}/${name}`
 }
 

--- a/packages/github/tests/utils.test.ts
+++ b/packages/github/tests/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test"
+import { getRepository, getRepositoryString, calculateHealthScore } from "../src/utils"
+
+describe("getRepository", () => {
+  it("parses owner and repo from full url", () => {
+    expect(getRepository("https://github.com/foo/bar")).toEqual({
+      owner: "foo",
+      name: "bar",
+    })
+  })
+
+  it("returns null for invalid url", () => {
+    expect(getRepository("not a url")).toBeNull()
+  })
+})
+
+describe("getRepositoryString", () => {
+  it("returns owner/name for valid url", () => {
+    expect(getRepositoryString("github.com/foo/bar")).toBe("foo/bar")
+  })
+
+  it("returns null for invalid input", () => {
+    expect(getRepositoryString("invalid")).toBeNull()
+  })
+})
+
+describe("calculateHealthScore", () => {
+  it("calculates a consistent score", () => {
+    const now = new Date()
+    const score = calculateHealthScore({
+      stars: 10,
+      forks: 5,
+      contributors: 2,
+      watchers: 4,
+      createdAt: now,
+      pushedAt: now,
+    })
+    expect(score).toBe(6)
+  })
+})


### PR DESCRIPTION
## Summary
- correct license spelling in README
- return `null` for invalid repo URLs in GitHub utilities
- clarify stack analysis rate-limiter comment
- log and early return when repo URL is invalid
- add tests for GitHub utility helpers

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_687000838ffc832c88d392d305157845