### PR TITLE
Fix repository URL parsing

### DIFF
--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -8,12 +8,17 @@ export const githubRegex =
  * Extracts the repository owner and name from a GitHub URL.
  *
  * @param url The GitHub URL from which to extract the owner and name.
- * @returns An object containing the repository owner and name, or null if the URL is invalid.
- */
+ * @returns An object containing the repository owner and name.
+ * @throws Will throw if the URL is not a valid GitHub repository.
+*/
 export const getRepository = (url: string): Repository => {
   const match = url.toLowerCase().match(githubRegex)
 
-  return match?.groups as Repository
+  if (!match || !match.groups) {
+    throw new Error(`Invalid GitHub repository URL: ${url}`)
+  }
+
+  return match.groups as Repository
 }
 
 /**


### PR DESCRIPTION
## Summary
- validate GitHub repository URLs in `getRepository`

## Testing
- `npm run lint` *(fails: The number of diagnostics exceeds the number allowed by Biome)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687000832bfc832cbf24a17ef79d2164